### PR TITLE
Added functionality for the user to specify cores via --cores

### DIFF
--- a/awe/workqueue.py
+++ b/awe/workqueue.py
@@ -184,7 +184,9 @@ class Config(object):
         self.monitor         = False	
         self.summaryfile     = ''
         self.capacity        = False
-
+        self.task_config     = {
+                                   "cores": 1,
+                               }
         self._executable = None
         self._cache = set()
 
@@ -651,7 +653,7 @@ class WorkQueue(object):
 
         cmd = self.cfg.executable.remotepath
         task = WQ.Task('./' + cmd)
-
+        task.specify_cores(self.cfg.task_config["cores"])
         ### executable
         self.cfg.executable.add_to_task(task)
 
@@ -902,7 +904,7 @@ class WorkQueue(object):
                 try:
                     result = marshall(task)
                 except Exception as ex:
-                    #print("In the exception")
+                    print("In the exception")
                     ### sometimes a task fails, but still returns.
                     ##+ attempt to restart these
                     if not self.restart(task):

--- a/scripts/awe-wq
+++ b/scripts/awe-wq
@@ -46,6 +46,7 @@ def getopts(args=None):
     g.add_option('-p', '--port', help='Port to run the master on (random|<int>) [%default]')
     g.add_option('--fast-abort', type=float, help='Use this fastabort multiplier [%default]')
     g.add_option('--debug',      action='store_true', help='Write WorkQueue debug information [%default]')
+    g.add_option('--cores', type=int, help='Use this to specify number of cores for each worker [%default]')
 
     p.add_option_group(g)
 
@@ -69,6 +70,7 @@ def getopts(args=None):
             port         = 'random',
             fast_abort   = False,
             debug        = False,
+	    cores	 = 1,
             )
 
 
@@ -116,6 +118,7 @@ def config(opts):
     if opts.debug:
         cfg.debug = opts.debug
 
+    cfg.cores = opts.cores
 
     # the "main" function of the worker
     cfg.execute(os.path.join(INSTANCE_ROOT, 'execute-task.sh'))
@@ -185,9 +188,7 @@ def main(opts):
                             system         = system,
                             iterations     = opts.iterations,
                             resample       = resampler,
-                            checkpointfreq = 1,
-                            verbose        = True,
-                            log_it         = True
+                            checkpointfreq = 1
                             )
         resampler.traxlogger._picklemode = 2
         resampler.traxlogger._pickleprotocol = 2


### PR DESCRIPTION
Altered awe/workqueue.py and scripts/awe-wq to allow the user to specify at the top level the number of cores to be utilized per worker.
