### PR TITLE
OpenMM and MSMBuilder Updates

### DIFF
--- a/awe/aweclasses.py
+++ b/awe/aweclasses.py
@@ -467,6 +467,8 @@ class AWE(object):
     def _resubmit(self):
         invalid = self.system.filter_by_valid()
         while invalid != {}:
+            if self.verbose:
+                print("Resubmitting invalid models")
             for cid in invalid:
                 valid = self.system.get_valid_walker(cid)
                 if valid is None:

--- a/awe/aweclasses.py
+++ b/awe/aweclasses.py
@@ -788,11 +788,11 @@ class AWE(object):
         os.unlink(result.tag)
         return walker
 
-        @typecheck(workqueue.WQ.Task)
-        def mark_invalid_task(self, task):
-            tag_info = self.decode_from_task_tag(task)
-            walker = self.system.walker(tag_info["walkerid"])
-            walker.mark_invalid()
+    @typecheck(workqueue.WQ.Task)
+    def mark_invalid_task(self, task):
+        tag_info = self.decode_from_task_tag(task)
+        walker = self.system.walker(tag_info["walkerid"])
+        walker.mark_invalid()
 
 
 

--- a/awe/aweclasses.py
+++ b/awe/aweclasses.py
@@ -790,7 +790,7 @@ class AWE(object):
 
     @typecheck(workqueue.WQ.Task)
     def mark_invalid_task(self, task):
-        tag_info = self.decode_from_task_tag(task)
+        tag_info = self.decode_from_task_tag(task.tag)
         walker = self.system.walker(tag_info["walkerid"])
         walker.mark_invalid()
 

--- a/awe/aweclasses.py
+++ b/awe/aweclasses.py
@@ -37,11 +37,11 @@ class Walker(object):
         initid     - the id of the walker at initialization
         start      - starting atomic coordinates
         end        - ending atomic coordinates
-        assignment - the cell assignment of the walker 
+        assignment - the cell assignment of the walker
         color      - the color of the walker
         natoms     - the number of atoms in the walker
         ndim       - the number of coordinate dimensions
-    
+
     Methods:
         restart - reset the walker to some initial conditions
     """
@@ -75,6 +75,7 @@ class Walker(object):
         self._color      = color
         self._weight     = weight
         self._cellid     = cellid
+        self._valid      = True
 
         # Assign the walker the next global id number if none was suuplies
         if wid is None:
@@ -175,6 +176,12 @@ class Walker(object):
     def ndim(self):       return self._coords.shape[-1]
 
     @property
+    def valid(self):      return self._valid;
+
+    def mark_invalid(self):
+        self._valid = False
+
+    @property
     def _coords(self):
         if self.start is not None:
             return self.start
@@ -198,13 +205,13 @@ class AWE(object):
 
     """
     The main driver for the Accelerated Weighted Ensemble algorithm.
-    
+
     This class manages the marshaling of workers to/from workers,
     updating the current WalkerGroup, and calling the resampleing
     algorithm.
 
     Fields:
-        wq             - 
+        wq             -
         system         -
         iterations     -
         resample       -
@@ -215,15 +222,15 @@ class AWE(object):
         checkpointfreq -
 
     Methods:
-        checkpoint               - 
-        logwalker                - 
-        recover                  - 
-        run                      - 
-        encode_task_tag          - 
-        decode_from_task_tag     - 
-        marshal_to_task          - 
-        specify_task_output_file - 
-        marshal_from_task        - 
+        checkpoint               -
+        logwalker                -
+        recover                  -
+        run                      -
+        encode_task_tag          -
+        decode_from_task_tag     -
+        marshal_to_task          -
+        specify_task_output_file -
+        marshal_from_task        -
     """
 
     # @typecheck(wqconfig=workqueue.Config, system=System, iterations=int)
@@ -242,14 +249,14 @@ class AWE(object):
 
         Returns:
             None
-        """ 
+        """
         self._verbose = verbose
         self._print_start_screen()
-        
+
         self.statslogger = stats.StatsLogger('debug/task_stats.log.gz')
         self.transitionslogger = stats.StatsLogger(
             'debug/cell-transitions.log.gz')
-	
+
         #self.tmpdir = tempfile.mkdtemp(prefix="awe-tmp.")
         self.wq = workqueue.WorkQueue(wqconfig, statslogger=self.statslogger, log_it=log_it)
         #self.wq.tmpdir = self.tmpdir
@@ -266,7 +273,7 @@ class AWE(object):
         self.traxlogger = traxlogger or trax.SimpleTransactional(
                                             checkpoint='debug/trax.cpt',
                                             log='debug/trax.log')
-        
+
         self.checkpointfreq = checkpointfreq
 
         self._firstrun  = True
@@ -301,7 +308,7 @@ class AWE(object):
             start_str += "WEB PAGE:\n"
             start_str += "  www.nd.edu/~ccl/software/awe\n"
             start_str += "***************************************************************************************************\n"
-            
+
             print(start_str)
 
     def checkpoint(self):
@@ -381,7 +388,7 @@ class AWE(object):
 
             # Get all attributes from the checkpoint
             parms = self.traxlogger.recover(self._trax_log_recover)
-            
+
             # Reset all AWE parameters
             for a in parms.keys():
                 setattr(self, a, parms[a])
@@ -417,7 +424,7 @@ class AWE(object):
         """
 
         self.currenttask += 1
-        
+
         # Give the task an identity
         task = self.wq.new_task()
         tag  = self.encode_task_tag(walker)
@@ -444,7 +451,7 @@ class AWE(object):
         while self.wq.can_duplicate_tasks():
             i += 1
             if i > 20: break
-            
+
             # Get a task that can be duplicated if one exists
             tag = self.wq.select_tag()
 
@@ -507,9 +514,9 @@ class AWE(object):
         # Keep track of how long it takes to resample
         if self._log:
             self.stats.time_resample('start')
-        
+
         self.system = self.resample(self.system)
-        
+
         if self._log:
             self.stats.time_resample('stop')
         #print("done resampling")
@@ -550,7 +557,7 @@ class AWE(object):
                     #fd.write(int.__str__(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)+"\n")
                 #print("MaxRSS Memory: %s" % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss))
                 #m = input("Press enter")
-                
+
                 # Update the checkpoint
                 if self.iteration % self.checkpointfreq == 0:
                     if self._verbose:
@@ -574,7 +581,7 @@ class AWE(object):
                 self._submit()
                 self._recv()     ## barrier
                 self._resample()
-                
+
                 if self._log:
                     self.stats.time_iter('stop')
 
@@ -633,7 +640,7 @@ class AWE(object):
                 'walkerid' : int(walkerid) ,
                 'outfile'  : outfile       }
 
-        
+
 
     @typecheck(int, workqueue.WQ.Task)
     def marshal_to_task(self, walker, task):
@@ -659,7 +666,7 @@ class AWE(object):
         #pkl_file = open(pkl_name, 'wb')
         #pickle.dump(walker, pkl_file)
         #pkl_file.close()
-        
+
         # Send the the topology and walker to the worker
         # See cctools work_queue.Task for more information
         task.specify_buffer(
@@ -714,7 +721,7 @@ class AWE(object):
         #else:
         #    print("Invalid tarfile: %s" % result.tag)
         tag_info = self.decode_from_task_tag(result.tag)
-        print(tag_info) 
+        print(tag_info)
         tar = tarfile.open(result.tag)
         try:
             #walkerstr         = tar.extractfile(workqueue.WORKER_WALKER_NAME).read()
@@ -722,7 +729,7 @@ class AWE(object):
 
             pdbstring         = tar.extractfile(workqueue.RESULT_POSITIONS).read()
             # print(pdbstring)
-            
+
             cellstring        = tar.extractfile(workqueue.RESULT_CELL).read()
             # print(cellstring)
         finally:
@@ -759,13 +766,19 @@ class AWE(object):
                 self.transitionslogger.update(time.time(), 'AWE', 'cell_transition',
                                       'iteration %s from %s to %s %s' % \
                                           (self.iteration, walker.assignment, cellid, transition))
-            
+
             # Update the walker's state
             walker.end        = coords
             walker.assignment = cellid
 
         os.unlink(result.tag)
         return walker
+
+        @typecheck(workqueue.WQ.Task)
+        def mark_invalid_task(self, task):
+            tag_info = self.decode_from_task_tag(task)
+            walker = self.system.walker(tag_info["walkerid"])
+            walker.mark_invalid()
 
 
 
@@ -899,7 +912,7 @@ class System(object):
         """
         Get the weights of all walkers in the System.
         """
-        
+
         return np.array(list(map(lambda w: w.weight, self.walkers)))
 
     @property
@@ -908,7 +921,7 @@ class System(object):
         """
         Get the colors of all walkers in the System.
         """
-        
+
         return set([w.color for w in self.walkers])#set(map(lambda w: w.color, self.walkers))
 
     @typecheck(Cell)

--- a/awe/aweclasses.py
+++ b/awe/aweclasses.py
@@ -1093,6 +1093,20 @@ class System(object):
 
         return newsys
 
+    def filter_by_valid(self):
+        invalid = {}
+        for c in self.cells:
+            walkers = self.filter_by_cell(c)
+            invalid[c.id] = [w for w in walkers if not w.valid]
+        return invalid
+
+    def get_valid_walker(self, cid):
+        c = self.cell(cid)
+        walkers = self.filter_by_cell(c)
+        for w in walkers:
+            if w.valid:
+                return w
+
     def clone(self, cells=True):
         """
         Make a copy the System instance.

--- a/awe/workqueue.py
+++ b/awe/workqueue.py
@@ -11,7 +11,7 @@ import awe
 
 import work_queue as WQ
 
-import os, tarfile, tempfile, time, shutil, traceback, random
+import os, tarfile, tempfile, time, shutil, traceback, random, re
 from collections import defaultdict
 from functools import reduce
 
@@ -128,26 +128,26 @@ class WQFile(object):
 class Config(object):
     """
     Configuration options for a WorkQueue instance.
-    
+
     Fields:
         name            - the name of this run of AWE-WQ
         port            - the port on which the WorkQueue master listens
         schedule        - the task scheduling algorithm to use
         exclusive       - whether or not the WorkQueue instance is singleton
-        catalog         - 
+        catalog         -
         debug           - which information to include in logs
-        shutdown        - 
-        fastabort       - 
+        shutdown        -
+        fastabort       -
         restarts        - the number of times to restart a failed task
-        maxreps         - 
-        waittime        - 
+        maxreps         -
+        waittime        -
         wq_logfile      - the log file for WorkQueue debug information
         wqstats_logfile - the log file for WorkQueue statistical information
-        monitor         - 
+        monitor         -
         summaryfile     - the log file for WorkQueue run basic information
-        capacity        - 
+        capacity        -
         _executable     - the script or executable that the task should run
-        _cache          - 
+        _cache          -
 
     Methods:
         execute - add the main program to run to the task cached file list
@@ -181,7 +181,7 @@ class Config(object):
         self.waittime        = 10 # in seconds
         self.wq_logfile      = 'debug/wq.log'
         self.wqstats_logfile = 'debug/wq-stats.log'
-        self.monitor         = False	
+        self.monitor         = False
         self.summaryfile     = ''
         self.capacity        = False
         self.task_config     = {
@@ -219,7 +219,7 @@ class Config(object):
             kws   - a dictionary of keyword-mapped arguments
 
         Keyword Arguments:
-            base       - a boolean value representing whether to use the 
+            base       - a boolean value representing whether to use the
                          current directory
             remotepath - the remote filepath to look in for files
 
@@ -256,33 +256,33 @@ class Config(object):
                 # Set up debugging parameters for the cctools WorkQueue object.
                 # It has inbuilt debugging capabilities.
                 WQ.set_debug_flag(self.debug)
-                
+
                 if self.wq_logfile:
                      awe.util.makedirs_parent(self.wq_logfile)
                      WQ.cctools_debug_config_file(self.wq_logfile)
-                     WQ.cctools_debug_config_file_size(0) 
-            
+                     WQ.cctools_debug_config_file_size(0)
+
             if self.name:
                 self.catalog = True
-            
+
             # Create the cctools WorkQueue object
             wq = WQ.WorkQueue(name      = self.name,
                               port      = self.port,
                               shutdown  = self.shutdown,
                               catalog   = self.catalog,
                               exclusive = self.exclusive)
-            
+
             # Specify the task scheduling algorithm
             wq.specify_algorithm(self.schedule)
-            
+
             # Turn cctools WorkQueue object status monitoring on or off
-            if self.monitor: 
+            if self.monitor:
                 wq.enable_monitoring(self.summaryfile)
 
             if self.capacity:
                 # Determine the number of workers the WorkQueue object can handle
     	        wq.estimate_capacity()
- 
+
             # Display information about this run of AWE-WQ
             awe.log('Running on port %d...' % wq.port)
             if wq.name:
@@ -301,7 +301,7 @@ class Config(object):
         # Ensure that the singleton is logging to the correct files
         awe.util.makedirs_parent(self.wqstats_logfile)
         _AWE_WORK_QUEUE.specify_log(self.wqstats_logfile)
-        
+
         # Return a reference to teh singleton
         return _AWE_WORK_QUEUE
 
@@ -455,15 +455,15 @@ class TagSet(object):
 
         if len(self) > 0:
             count  = 1
-            
+
             # Keys are ordinal (likely integers), so min(keys) is the tag set
             # representing tags with the least number of duplicates.
             minkey = min(self._tags.keys())
-            
+
             assert len(self._tags[minkey]) > 0, str(minkey) + ', ' + str(self._tags[minkey])
-            
+
             return random.sample(self._tags[minkey], count)[0]
-        
+
         else:
             return None
 
@@ -523,9 +523,9 @@ class WorkQueue(object):
 
     Methods:
         update_task_stats   -
-        new_task            - 
-        submit              - 
-        restart             - 
+        new_task            -
+        submit              -
+        restart             -
         wait                -
         taskoutput          -
         add_tag             -
@@ -536,7 +536,7 @@ class WorkQueue(object):
         clear               -
         tasks_in_queue      -
         active_workers      -
-        can_duplicate_tasks - 
+        can_duplicate_tasks -
         recv                -
     """
 
@@ -618,7 +618,7 @@ class WorkQueue(object):
         Returns:
             None
         """
-        
+
         import shutil
         shutil.rmtree(self.tmpdir)
 
@@ -706,7 +706,7 @@ class WorkQueue(object):
             self.submit(task)
             self.restarts[task.tag] += 1
             return True
-        
+
         # Otherwise, do not restart the task
         else:
             return False
@@ -715,7 +715,7 @@ class WorkQueue(object):
         """
         Set the cctools work_queue.WorkQueue instance to idle state (usually
         if no workers are available).
-        
+
         Parameters: (see the cctools module work_queue.py for more information)
             args - arguments for wq.wait
             kws  - keyword arguments for wq.wait
@@ -813,7 +813,7 @@ class WorkQueue(object):
     def clear(self):
         """
         Remove all tags from the internal tag set dictionary and all tasks from
-        the cctools work_queue.WorkQueue object instance. 
+        the cctools work_queue.WorkQueue object instance.
         """
 
         self.clear_tags()
@@ -825,7 +825,7 @@ class WorkQueue(object):
         """
         The number of tasks currently running and waiting in the queue.
 
-        Parameters: 
+        Parameters:
             None
 
         Returns:
@@ -845,7 +845,7 @@ class WorkQueue(object):
             An integer representing the number of workers not idle
         """
 
-        return self.wq.stats.workers_busy + self.wq.stats.workers_ready 
+        return self.wq.stats.workers_busy + self.wq.stats.workers_ready
 
     def can_duplicate_tasks(self):
         """
@@ -864,7 +864,7 @@ class WorkQueue(object):
             and self._tagset.can_duplicate()
 
 
-    def recv(self, marshall):
+    def recv(self, marshall, mark_invalid):
         """
         Deal with tasks as they return. Handle successes, errors, and restarts.
         Runs forever.
@@ -919,6 +919,10 @@ class WorkQueue(object):
                 return result
 
             elif task and not task.result == 0:
+                # Check the task output for a bad model
+                if re.match(r'NaN', task.output):
+                    mark_invalid(task)
+                    continue
                 # Kill the task if it cannot be restarted.
                 if not self.restart(task):
                     raise WorkQueueException('Task exceeded maximum number of resubmissions for %s\n\n%s' % \

--- a/awe/workqueue.py
+++ b/awe/workqueue.py
@@ -541,7 +541,7 @@ class WorkQueue(object):
     """
 
     # @awe.typecheck(Config)
-    def __init__(self, cfg, statslogger=None, taskoutputlogger=None, log_it=False):
+    def __init__(self, cfg, statslogger=None, taskoutputlogger=None, verbose=False, log_it=False):
         """
         Initialize a new instance of WorkQueue for managing the cctools
         work_queue.WorkQueue object with the necessary parameters for running
@@ -579,6 +579,7 @@ class WorkQueue(object):
         self.statslogger      = statslogger      or awe.stats.StatsLogger(buffersize=42)
         self.taskoutputlogger = taskoutputlogger or awe.stats.StatsLogger(path='debug/task_output.log.gz', buffersize=42)
         self._log = log_it
+        self.verbose = verbose
 
     @property
     def empty(self):
@@ -921,6 +922,8 @@ class WorkQueue(object):
             elif task and not task.result == 0:
                 # Check the task output for a bad model
                 if task.output.find('Exception: Particle coordinate is NaN'):
+                    if self.verbose:
+                        print(''.join([task.tag, ': Particle coordinate is NaN']))
                     mark_invalid(task)
                     continue
                 # Kill the task if it cannot be restarted.

--- a/awe/workqueue.py
+++ b/awe/workqueue.py
@@ -920,7 +920,7 @@ class WorkQueue(object):
 
             elif task and not task.result == 0:
                 # Check the task output for a bad model
-                if re.match(r'NaN', task.output):
+                if task.output.find('Exception: Particle coordinate is NaN'):
                     mark_invalid(task)
                     continue
                 # Kill the task if it cannot be restarted.

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -137,7 +137,7 @@ def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
                 label = clusterer.labels_[i][j]
                 center = msm.mapping_[label]
                 dist = np.linalg.norm(clustering[i][j] - centers[label])
-                if center != -1 and dist < dists[label]:
+                if center != -1 and dist < dists[center]:
                     dists[center] = dist
                     centermap[center] = (i, j)
             except KeyError:

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -5,11 +5,15 @@ Extract AWE inputs from an existing MSM and corresponding clustering.
 Author: Jeff Kinnison <jkinniso@nd.edu>
 """
 
+# Python Standard Library imports
 import argparse
 import copy
 import glob
 import os
 import os.path
+import subprocess
+
+# Third-Party imports
 import mdtraj
 from msmbuilder.dataset import dataset
 from msmbuilder.utils import load, draw_samples
@@ -19,96 +23,294 @@ import numpy as np
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-n', '--n-samples',
-                        required=True,
-                        type=int,
-                        help='the number of samples to draw from each MSM state'
-                        )
+    # General Options
+    general = parser.add_group('General Arguments')
 
-    parser.add_argument('-m', '--msm',
-                        default='msm.pkl',
+    general.add_argument('-i', '--input-trajectories',
+                        default='trajectories/*',
                         type=str,
-                        help='path to the serialized MSMBuilder msm object'
+                        help='path or glob to the input trajectories'
                         )
 
-    parser.add_argument('-c', '--clustering',
-                        default='clustering/',
-                        type=str,
-                        help='path to the clustered data'
-                        )
-
-    parser.add_argument('-C', '--clusterer',
-                        default='clusterer.pkl',
-                        type=str,
-                        help='path to serialized clusterer fit to clustering'
-                        )
-
-    parser.add_argument('-i', '--input-trajectories',
-                        default='trajectories',
-                        type=str,
-                        help='path to the input trajectories'
-                        )
-
-    parser.add_argument('-t', '--topology',
+    general.add_argument('-t', '--topology',
                         default='input.pdb',
                         type=str,
                         help='path to the trajectory topology file'
                         )
 
-    parser.add_argument('-r', '--reference',
+    general.add_argument('-r', '--reference',
                         default='folded.pdb',
                         type=str,
                         help='path to the reference trajectory'
                         )
 
-    parser.add_argument('-a', '--atom-selection',
-                        default='backbone',
+    # Featurization Options
+
+    featurize = parser.add_group("Featurization Arguments")
+
+    featurize.add_argument('-f', '--featurizer',
+                           default='DihedralFeaturizer',
+                           type=str,
+                           help='MSMBuilder featurizer class to use'
+                           choices=['ContactFeaturizer',
+                                    'DRIDFeaturizer',
+                                    'DihedralFeaturizer',
+                                    'RMSDFeaturizer',
+                                    'RawPositionsFeaturizer']
+                           )
+
+    featurize.add_argument('--featurizer-out',
+                           default='feat.pkl',
+                           type=str,
+                           help='path to the file that will store the serialized featurizer',
+                           )
+
+    featurize.add_argument('--featurized-data',
+                           default='feats.h5',
+                           type=str,
+                           help='path to the file that will store the featurized data'
+                           )
+
+    featurize.add_argument('--featurizer-args',
+                           default='',
+                           type=str,
+                           help='a comma-delimited list of additional arguments to the featurizer (e.g. --arg1,val1,--arg2,val2)'
+                           )
+
+    # Decomposition Options
+
+    decomp = parser.add_group('Decomposition Options')
+
+    decomp.add_argument('-d', '--decomposer',
+                        default='tICA',
                         type=str,
-                        help='MDTraj/VMD atom selection string'
+                        help='MSMBuilder decomposition class to use',
+                        choices=['PCA',
+                                 'SparseTICA',
+                                 'tICA']
                         )
 
-    parser.add_argument('--samples-out',
-                        default='samples',
+    decomp.add_argument('--decomp-out',
+                        default='tica.pkl',
                         type=str,
-                        help='path to the cell sampling output directory'
+                        help='path to the file that will store the serialized decomposer',
                         )
 
-    parser.add_argument('--centers-out',
-                        default='centers',
+    decomp.add_argument('--decomp-data',
+                        default='ticas.h5',
                         type=str,
-                        help='path to the cell centers output directory'
+                        help='path to the file that will store the decomposed data'
                         )
 
-    parser.add_argument('--folded-assignments',
-                        default=['folded.dat', 'unfolded.dat']
-                        nargs=2,
+    decomp.add_argument('--n-components',
+                        default=5,
+                        type=int,
+                        help='the number of components to find in the decomposition')
+
+    decomp.add_argument('--decomp-args',
+                        default='',
                         type=str,
-                        help='paths to the cell assignment output files'
+                        help='a comma-delimited list of additional arguments to the decomposer (e.g. --arg1,val1,--arg2,val2)'
                         )
 
-    parser.add_argument('--folded-threshold',
-                        default=3.0,
-                        type=float,
-                        help='RMSD to folded state threshold (AA)'
+    # Clustering Options
+
+    cluster = parser.add_group('Clustering Options')
+
+    cluster.add_argument('-c', '--clusterer',
+                        default='MiniBatchKMeans',
+                        type=str,
+                        help='MSMBuilder clusterer class to use',
+                        choices=['AffinityPropagation',
+                                 'GMM',
+                                 'KCenters',
+                                 'KMeans',
+                                 'KMedoids',
+                                 'LandmarkAgglomerative',
+                                 'MeanShift',
+                                 'MiniBatchKMeans',
+                                 'MiniBatchKMedoids',
+                                 'RegularSpatial',
+                                 'SpectralClustering',
+                                 'Ward']
                         )
 
-    parser.add_argument('--cells-datafile',
-                        default='cells.dat',
-                        type=str,
-                        help='the cell data output file'
-                        )
+    cluster.add_argument('--clusterer-out',
+                         default='cluster.pkl',
+                         type=str,
+                         help='path to the file that will store the serialized clusterer',
+                         )
 
-    parser.add_argument('--weights-datafile',
-                        default='weights.dat',
-                        type=str,
-                        help='the cell weights data output file',
-                        )
+    cluster.add_argument('--clustered-data',
+                         default='labeled-trajs.h5',
+                         type=str,
+                         help='path to the file that will store the clustered data'
+                         )
+
+    cluster.add_argument('--n-clusters',
+                         default=100,
+                         type=int,
+                         help='the target number of clusters to find'
+                         )
+
+    cluster.add_argument('--clusterer-args',
+                         default='',
+                         type=str,
+                         help='a comma-delimited list of additional arguments to the clusterer (e.g. --arg1,val1,--arg2,val2)'
+                         )
+
+    # MSM Options
+
+    msm = parser.add_group('MSM Options')
+
+    msm.add_argument('-m', '--msm',
+                     default='tICA',
+                     type=str,
+                     help='MSMBuilder msmer class to use',
+                     choices=['BayesianMSM', 'MSM']
+                     )
+
+    msm.add_argument('--msm-out',
+                     default='msm.pkl',
+                     type=str,
+                     help='path to the file that will store the serialized msmer',
+                     )
+
+    msm.add_argument('--lag-time',
+                     default=1,
+                     type=int,
+                     help='lag time for determinig MSM populations')
+
+    msm.add_argument('--msm-args',
+                     default='',
+                     type=str,
+                     help='a comma-delimited list of additional arguments to the msmer (e.g. --arg1,val1,--arg2,val2)'
+                     )
+
+    # Sampling Options
+
+    sampling = parser.add_group('Sampling Options')
+
+    sampling.add_argument('-n', '--n-samples',
+                          required=True,
+                          type=int,
+                          help='the number of samples to draw from each MSM state'
+                          )
+
+    sampling.add_argument('-a', '--atom-selection',
+                          default='backbone',
+                          type=str,
+                          help='MDTraj/VMD atom selection string'
+                          )
+
+    sampling.add_argument('--samples-out',
+                          default='samples',
+                          type=str,
+                          help='path to the cell sampling output directory'
+                          )
+
+    sampling.add_argument('--centers-out',
+                          default='centers',
+                          type=str,
+                          help='path to the cell centers output directory'
+                          )
+
+    sampling.add_argument('--folded-assignments',
+                          default=['folded.dat', 'unfolded.dat']
+                          nargs=2,
+                          type=str,
+                          help='paths to the cell assignment output files'
+                          )
+
+    sampling.add_argument('--folded-threshold',
+                          default=3.0,
+                          type=float,
+                          help='RMSD to folded state threshold (AA)'
+                          )
+
+    sampling.add_argument('--cells-datafile',
+                          default='cells.dat',
+                          type=str,
+                          help='the cell data output file'
+                          )
+
+    sampling.add_argument('--weights-datafile',
+                          default='weights.dat',
+                          type=str,
+                          help='the cell weights data output file',
+                          )
 
     return parser.parse_args(args)
 
 
+def featurize(args):
+    """
+
+    """
+    cmd = ['msmb', args.featurizer,
+           '--out', args.featurizer_out,
+           '--transformed', args.featurized_data,
+           '--top', args.topology,
+           '--trjs', args.input_trajectories].extend(args.featurizer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Featurization failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def decompose(args):
+    """
+
+    """
+    cmd = ['msmb', args.decomposer,
+           '-i', args.featurized_data,
+           '--out', args.decomposer_out,
+           '--transformed', args.decomposed_data,
+           '--n_components', str(args.n_components)].extend(args.decomposer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Decomposition failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def cluster(args):
+    """
+
+    """
+    cmd = ['msmb', args.clusterer,
+           '-i', args.decomposed_data,
+           '--out', args.clusterer_out,
+           '--transformed', args.clustered_data,
+           '--n_clusters', str(args.n_clusters)].extend(args.clusterer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Clustering failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def build_msm():
+    """
+
+    """
+    cmd = ['msmb', args.msm,
+           '-i', args.clustered_data,
+           '--out', args.msm_out,
+           '--lag_time', str(args.lag_time)].extend(args.decomposer_args.split(','))
+    try:
+        subprocess.run('msmb MarkovStateModel -i labeled-trajs.h5 --out msm.pkl --lag_time 1',
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: MSM Building failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
 def save_samples(msm, clustering, xyz, n_samples, samples_dir):
     """
+    Extract samples from each state in the MSM and save each as an individual PDB.
+
 
     """
     samples = msm.draw_samples(clustering, n_samples)
@@ -184,9 +386,9 @@ def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
                                  str(atom[1]), '\n',
                                  str(atom[2]), '\n']))
 
-        folded.close()
-        unfolded.close()
-        cells.close()
+    folded.close()
+    unfolded.close()
+    cells.close()
 
 
 def save_weights(msm, weights_out):
@@ -199,8 +401,13 @@ def save_weights(msm, weights_out):
 if __name__ == "__main__":
     args = parse_args(None)
 
+    featurize(args)
+    decompose(args)
+    cluster(args)
+    build_msm(args)
+
     msm = load(args.msm)
-    clustering = dataset(args.clustering)
+    clustering = dataset(args.clustered_data)
     clusterer = load(args.clusterer)
     xyz = dataset(args.input_trajectories, args.topology)
 

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -389,8 +389,8 @@ def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    dists = {}
-    centermap = {}
+    dists = {val: float('inf') for key, val in msm.mapping_.items}
+    centermap = {val: (-1, -1) for key, val in msm.mapping_.items}
 
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -434,7 +434,7 @@ def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
                          '\nndims: ', str(3), '\n\n']))
 
     for i in range(0, n_cells):
-        fname = ''.join('Center', str(i), '.pdb')
+        fname = ''.join(['Center', str(i), '.pdb'])
         traj = mdtraj.load(os.path.join(centers_dir, fname))
         rmsd = mdtraj.rmsd(traj, ref,
                            atom_indices=traj.topology.select(atom_selection))

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -389,8 +389,8 @@ def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    dists = {val: float('inf') for key, val in msm.mapping_.items}
-    centermap = {val: (-1, -1) for key, val in msm.mapping_.items}
+    dists = {val: float('inf') for key, val in msm.mapping_.items()}
+    centermap = {val: (-1, -1) for key, val in msm.mapping_.items()}
 
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -24,7 +24,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser()
 
     # General Options
-    general = parser.add_group('General Arguments')
+    general = parser.add_argument_group('General Arguments')
 
     general.add_argument('-i', '--input-trajectories',
                         default='trajectories/*',
@@ -46,12 +46,12 @@ def parse_args(args=None):
 
     # Featurization Options
 
-    featurize = parser.add_group("Featurization Arguments")
+    featurize = parser.add_argument_group("Featurization Arguments")
 
     featurize.add_argument('-f', '--featurizer',
                            default='DihedralFeaturizer',
                            type=str,
-                           help='MSMBuilder featurizer class to use'
+                           help='MSMBuilder featurizer class to use',
                            choices=['ContactFeaturizer',
                                     'DRIDFeaturizer',
                                     'DihedralFeaturizer',
@@ -66,20 +66,20 @@ def parse_args(args=None):
                            )
 
     featurize.add_argument('--featurized-data',
-                           default='feats.h5',
+                           default='feats',
                            type=str,
                            help='path to the file that will store the featurized data'
                            )
 
     featurize.add_argument('--featurizer-args',
-                           default='',
+                           default=None,
                            type=str,
                            help='a comma-delimited list of additional arguments to the featurizer (e.g. --arg1,val1,--arg2,val2)'
                            )
 
     # Decomposition Options
 
-    decomp = parser.add_group('Decomposition Options')
+    decomp = parser.add_argument_group('Decomposition Options')
 
     decomp.add_argument('-d', '--decomposer',
                         default='tICA',
@@ -108,14 +108,14 @@ def parse_args(args=None):
                         help='the number of components to find in the decomposition')
 
     decomp.add_argument('--decomp-args',
-                        default='',
+                        default=None,
                         type=str,
                         help='a comma-delimited list of additional arguments to the decomposer (e.g. --arg1,val1,--arg2,val2)'
                         )
 
     # Clustering Options
 
-    cluster = parser.add_group('Clustering Options')
+    cluster = parser.add_argument_group('Clustering Options')
 
     cluster.add_argument('-c', '--clusterer',
                         default='MiniBatchKMeans',
@@ -154,20 +154,20 @@ def parse_args(args=None):
                          )
 
     cluster.add_argument('--clusterer-args',
-                         default='',
+                         default=None,
                          type=str,
                          help='a comma-delimited list of additional arguments to the clusterer (e.g. --arg1,val1,--arg2,val2)'
                          )
 
     # MSM Options
 
-    msm = parser.add_group('MSM Options')
+    msm = parser.add_argument_group('MSM Options')
 
     msm.add_argument('-m', '--msm',
-                     default='tICA',
+                     default='MarkovStateModel',
                      type=str,
                      help='MSMBuilder msmer class to use',
-                     choices=['BayesianMSM', 'MSM']
+                     choices=['BayesianMSM', 'MarkovStateModel']
                      )
 
     msm.add_argument('--msm-out',
@@ -182,14 +182,14 @@ def parse_args(args=None):
                      help='lag time for determinig MSM populations')
 
     msm.add_argument('--msm-args',
-                     default='',
+                     default=None,
                      type=str,
                      help='a comma-delimited list of additional arguments to the msmer (e.g. --arg1,val1,--arg2,val2)'
                      )
 
     # Sampling Options
 
-    sampling = parser.add_group('Sampling Options')
+    sampling = parser.add_argument_group('Sampling Options')
 
     sampling.add_argument('-n', '--n-samples',
                           required=True,
@@ -216,7 +216,7 @@ def parse_args(args=None):
                           )
 
     sampling.add_argument('--folded-assignments',
-                          default=['folded.dat', 'unfolded.dat']
+                          default=['folded.dat', 'unfolded.dat'],
                           nargs=2,
                           type=str,
                           help='paths to the cell assignment output files'
@@ -251,9 +251,20 @@ def featurize(args):
            '--out', args.featurizer_out,
            '--transformed', args.featurized_data,
            '--top', args.topology,
-           '--trjs', args.input_trajectories].extend(args.featurizer_args.split(','))
+           '--trjs', args.input_trajectories]
+
+    if args.featurizer_args is not None:
+        cmd.extend(args.featurizer_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'featurize.out'), 'w')
+        err = open(os.path.join('logs', 'featurize.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Featurization failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
@@ -265,11 +276,22 @@ def decompose(args):
     """
     cmd = ['msmb', args.decomposer,
            '-i', args.featurized_data,
-           '--out', args.decomposer_out,
-           '--transformed', args.decomposed_data,
-           '--n_components', str(args.n_components)].extend(args.decomposer_args.split(','))
+           '--out', args.decomp_out,
+           '--transformed', args.decomp_data,
+           '--n_components', str(args.n_components)]
+
+    if args.decomp_args is not None:
+        cmd.extend(args.decomp_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'decomp.out'), 'w')
+        err = open(os.path.join('logs', 'decomp.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Decomposition failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
@@ -280,65 +302,105 @@ def cluster(args):
 
     """
     cmd = ['msmb', args.clusterer,
-           '-i', args.decomposed_data,
+           '-i', args.decomp_data,
            '--out', args.clusterer_out,
            '--transformed', args.clustered_data,
-           '--n_clusters', str(args.n_clusters)].extend(args.clusterer_args.split(','))
+           '--n_clusters', str(args.n_clusters)]
+
+    if args.clusterer_args is not None:
+        cmd.extend(args.clusterer_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'cluster.out'), 'w')
+        err = open(os.path.join('logs', 'cluster.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Clustering failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
 
 
-def build_msm():
+def build_msm(args):
     """
 
     """
     cmd = ['msmb', args.msm,
            '-i', args.clustered_data,
            '--out', args.msm_out,
-           '--lag_time', str(args.lag_time)].extend(args.decomposer_args.split(','))
+           '--lag_time', str(args.lag_time)]
+
+    if args.msm_args is not None:
+        cmd.extend(args.msm_args.split(','))
+
     try:
-        subprocess.run('msmb MarkovStateModel -i labeled-trajs.h5 --out msm.pkl --lag_time 1',
-                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'msm.out'), 'w')
+        err = open(os.path.join('logs', 'msm.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: MSM Building failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
 
 
-def save_samples(msm, clustering, xyz, n_samples, samples_dir):
+def save_samples(msm, labels, xyz, n_samples, samples_dir):
     """
     Extract samples from each state in the MSM and save each as an individual PDB.
 
 
     """
-    samples = msm.draw_samples(clustering, n_samples)
-    frames = draw_samples.map_drawn_samples(samples, xyz)
 
-    if not os.path.isdir(samples_dir):
-        os.mkdir(samples_dir)
+    state_count = {val: 0 for key, val in msm.mapping_.items()}
 
-    for i in range(0, msm.n_states_):
-        for j in range(0, n_samples):
-            samples = ''.join(['State', str(i), '-', str(j), '.pdb'])
-            frames[i][j].save(os.path.join(samples_dir, sample))
+    for i in range(0, len(labels)):
+        for j in range(0, len(labels[i])):
+            try:
+                state = msm.mapping_[labels[i][j]]
+                if state_count[state] < n_samples:
+                    num = state_count[state]
+                    filename = ''.join(['State', str(state), '-', str(num), '.pdb'])
+                    xyz[i][j].save(os.path.join(samples_dir, filename))
+                    state_count[state] += 1
+            except KeyError:
+                continue
+
+    print("Creating duplicates for low-population states...")
+    for key, val in state_count.items():
+        if val == 0:
+            print("Warning: No samples found in state %s" % (key))
+        elif key < n_samples:
+            print("Creating duplicates for state %s" % (key))
+            filename = ''.join(['State', str(key), '-0.pdb'])
+            traj = mdtraj.load(os.path.join(samples_dir, filename))
+            while val < n_samples:
+                outname = ''.join(['State', str(key), '-', str(val), '.pdb'])
+                traj.save(os.path.join(samples_dir, outname))
+                val += 1
 
 
-def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
+def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    centers = clusterer.cluster_centers_
     dists = {}
     centermap = {}
+
+    if not os.path.isdir(centers_dir):
+        os.mkdir(centers_dir)
 
     for i in range(0, len(clustering)):
         for j in range(0, len(clustering[i])):
             try:
-                label = clusterer.labels_[i][j]
+                label = clustering[i][j]
                 center = msm.mapping_[label]
-                dist = np.linalg.norm(clustering[i][j] - centers[label])
+                dist = np.linalg.norm(decomp[i][j] - clusterer.cluster_centers_[label])
                 if center != -1 and dist < dists[center]:
                     dists[center] = dist
                     centermap[center] = (i, j)
@@ -348,7 +410,7 @@ def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)
 
-    for key, val in centermap.iteritems():
+    for key, val in centermap.items():
         fname = ''.join(['Center', str(key), '.pdb'])
         traj = xyz[val[0]].slice([val[1]])
         traj.save(os.path.join(centers_dir, fname))
@@ -401,23 +463,34 @@ def save_weights(msm, weights_out):
 if __name__ == "__main__":
     args = parse_args(None)
 
+    print("Featurizing...")
     featurize(args)
+    print("Generating decomposition...")
     decompose(args)
+    print("Clustering...")
     cluster(args)
+    print("Building MSM...")
     build_msm(args)
 
-    msm = load(args.msm)
+    msm = load(args.msm_out)
     clustering = dataset(args.clustered_data)
-    clusterer = load(args.clusterer)
-    xyz = dataset(args.input_trajectories, args.topology)
+    clusterer = load(args.clusterer_out)
+    xyz = dataset(args.input_trajectories, topology=args.topology)
 
+    print("Saving %s samples per cell..." % (args.n_samples))
     save_samples(msm, clustering, xyz, args.n_samples, args.samples_out)
-    save_state_centers(msm, clustering, clusterer, xyz, args.centers_out)
+    print("Saving state centers...")
+    ticas = dataset(args.decomp_data)
+    save_state_centers(msm, clustering, clusterer, ticas, xyz, args.centers_out)
+    print("Saving cell weights...")
     save_weights(msm, args.weights_datafile)
     del msm
     del clustering
     del clusterer
     del xyz
-    save_cell_assignments(args.centers_out, args.reference, args.threshold,
+    del ticas
+    print("Saving cell color assignments and cell definitions...")
+    save_cell_assignments(args.centers_out, args.reference, args.folded_threshold,
                           args.atom_selection, args.folded_assignments[0],
                           args.folded_assignments[1], args.cells_datafile)
+    print("Done!")

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+"""
+Extract AWE inputs from an existing MSM and corresponding clustering.
+
+Author: Jeff Kinnison <jkinniso@nd.edu>
+"""
+
+import argparse
+import copy
+import glob
+import os
+import os.path
+import mdtraj
+from msmbuilder.dataset import dataset
+from msmbuilder.utils import load, draw_samples
+import numpy as np
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-n', '--n-samples',
+                        required=True,
+                        type=int,
+                        help='the number of samples to draw from each MSM state'
+                        )
+
+    parser.add_argument('-m', '--msm',
+                        default='msm.pkl',
+                        type=str,
+                        help='path to the serialized MSMBuilder msm object'
+                        )
+
+    parser.add_argument('-c', '--clustering',
+                        default='clustering/',
+                        type=str,
+                        help='path to the clustered data'
+                        )
+
+    parser.add_argument('-C', '--clusterer',
+                        default='clusterer.pkl',
+                        type=str,
+                        help='path to serialized clusterer fit to clustering'
+                        )
+
+    parser.add_argument('-i', '--input-trajectories',
+                        default='trajectories',
+                        type=str,
+                        help='path to the input trajectories'
+                        )
+
+    parser.add_argument('-t', '--topology',
+                        default='input.pdb',
+                        type=str,
+                        help='path to the trajectory topology file'
+                        )
+
+    parser.add_argument('-r', '--reference',
+                        default='folded.pdb',
+                        type=str,
+                        help='path to the reference trajectory'
+                        )
+
+    parser.add_argument('-a', '--atom-selection',
+                        default='backbone',
+                        type=str,
+                        help='MDTraj/VMD atom selection string'
+                        )
+
+    parser.add_argument('--samples-out',
+                        default='samples',
+                        type=str,
+                        help='path to the cell sampling output directory'
+                        )
+
+    parser.add_argument('--centers-out',
+                        default='centers',
+                        type=str,
+                        help='path to the cell centers output directory'
+                        )
+
+    parser.add_argument('--folded-assignments',
+                        default=['folded.dat', 'unfolded.dat']
+                        nargs=2,
+                        type=str,
+                        help='paths to the cell assignment output files'
+                        )
+
+    parser.add_argument('--folded-threshold',
+                        default=3.0,
+                        type=float,
+                        help='RMSD to folded state threshold (AA)'
+                        )
+
+    parser.add_argument('--cells-datafile',
+                        default='cells.dat',
+                        type=str,
+                        help='the cell data output file'
+                        )
+
+    parser.add_argument('--weights-datafile',
+                        default='weights.dat',
+                        type=str,
+                        help='the cell weights data output file',
+                        )
+
+    return parser.parse_args(args)
+
+
+def save_samples(msm, clustering, xyz, n_samples, samples_dir):
+    """
+
+    """
+    samples = msm.draw_samples(clustering, n_samples)
+    frames = draw_samples.map_drawn_samples(samples, xyz)
+
+    if not os.path.isdir(samples_dir):
+        os.mkdir(samples_dir)
+
+    for i in range(0, msm.n_states_):
+        for j in range(0, n_samples):
+            samples = ''.join(['State', str(i), '-', str(j), '.pdb'])
+            frames[i][j].save(os.path.join(samples_dir, sample))
+
+
+def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
+    """
+
+    """
+    centers = clusterer.cluster_centers_
+    dists = {}
+    centermap = {}
+
+    for i in range(0, len(clustering)):
+        for j in range(0, len(clustering[i])):
+            try:
+                label = clusterer.labels_[i][j]
+                center = msm.mapping_[label]
+                dist = np.linalg.norm(clustering[i][j] - centers[label])
+                if center != -1 and dist < dists[label]:
+                    dists[center] = dist
+                    centermap[center] = (i, j)
+            except KeyError:
+                continue
+
+    if not os.path.isdir(centers_dir):
+        os.mkdir(centers_dir)
+
+    for key, val in centermap.iteritems():
+        fname = ''.join(['Center', str(key), '.pdb'])
+        traj = xyz[val[0]].slice([val[1]])
+        traj.save(os.path.join(centers_dir, fname))
+
+
+def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
+                          folded_out, unfolded_out, cells_out):
+    """
+
+    """
+    ref = mdtraj.load(reference)
+
+    n_cells = len(glob.glob(os.path.join(centers_dir, '*.pdb')))
+
+    folded = open(folded_out, 'w')
+    unfolded = open(unfolded_out, 'w')
+    cells = open(cells_out, 'w')
+
+    cells.write(''.join(['ncells: ', str(n_cells),
+                         '\nncoords: ', str(ref.n_atoms),
+                         '\nndims: ', str(3), '\n\n']))
+
+    for i in range(0, n_cells):
+        fname = ''.join('Center', str(i), '.pdb')
+        traj = mdtraj.load(os.path.join(centers_dir, fname))
+        rmsd = mdtraj.rmsd(traj, ref,
+                           atom_indices=traj.topology.select(atom_selection))
+        if rmsd[0] < threshold:
+            folded.write(''.join([str(i), '\n']))
+        else:
+            unfolded.write(''.join([str(j), '\n']))
+
+        for atom in traj.xyz[0]:
+            cells.write(''.join([str(atom[0]), '\n',
+                                 str(atom[1]), '\n',
+                                 str(atom[2]), '\n']))
+
+        folded.close()
+        unfolded.close()
+        cells.close()
+
+
+def save_weights(msm, weights_out):
+    """
+
+    """
+    np.savetxt(weights_out, msm.populations_)
+
+
+if __name__ == "__main__":
+    args = parse_args(None)
+
+    msm = load(args.msm)
+    clustering = dataset(args.clustering)
+    clusterer = load(args.clusterer)
+    xyz = dataset(args.input_trajectories, args.topology)
+
+    save_samples(msm, clustering, xyz, args.n_samples, args.samples_out)
+    save_state_centers(msm, clustering, clusterer, xyz, args.centers_out)
+    save_weights(msm, args.weights_datafile)
+    del msm
+    del clustering
+    del clusterer
+    del xyz
+    save_cell_assignments(args.centers_out, args.reference, args.threshold,
+                          args.atom_selection, args.folded_assignments[0],
+                          args.folded_assignments[1], args.cells_datafile)

--- a/scripts/awe-wq
+++ b/scripts/awe-wq
@@ -150,7 +150,7 @@ def config(opts):
     else:
         # This branch performs setup for OpenMM
         cfg.cache(opts.openmm_script, remotepath='simulate.py')
-        cfg.cache(INSTANCE_ROOT, 'openmm', env.sh)
+        cfg.cache(os.path.join(INSTANCE_ROOT, 'openmm', 'env.sh'))
 
     cfg.cache(opts.cells, remotepath='cells.dat')
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup( author       = "Badi' Abdul-Wahid",
        name         = 'awe',
        packages     = ['awe'],
        scripts      = get_executables(),
-       data_files   = datafiles,
+       data_files   = [('share/awe', datafiles)],
        platforms    = ['Linux', 'Mac OS X'],
        description  = 'Accelerated Weighted Ensemble method for Molecular Dynamics using WorkQueue'
        )


### PR DESCRIPTION
This merge adds OpenMM and MSMBuilder 3.x into AWE-WQ.

OpenMM
- Choose to use OpenMM instead of GROMACS for simulation by passing `--enable-openmm` as an argument to the `awe-wq` script
- Default inputs are provided for both GROMACS and OpenMM in the `awe-instance-data` folder, sandboxed in subdirectories
- OpenMM currently requires that simulations be run on the CRC nodes to have guaranteed access to an OpenMM install and Python runtime

MSMBuilder
- Preparing inputs for AWE-WQ is now handled automatically by running `awe-generate-inputs -n <n_samples_per_cell>`
- All default MSMBuilder commands can be substituted at the command line (run `awe-generate-inputs -h` for instructions
- Sampling and cell assignment parameters are also customizable at the command line
